### PR TITLE
install target: use relative path instead of absolute path

### DIFF
--- a/Makefile.subdirs
+++ b/Makefile.subdirs
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-TOPDIR := $(shell git rev-parse --show-toplevel)
-DESTDIR ?= $(TOPDIR)/proto
+DESTDIR ?= ../../proto
 
 all: TARGET += all
 clean: TARGET += clean


### PR DESCRIPTION
To allow building from a tarball. If the tarball is built in a different
git workspace then "proto/" would be created at the top of that
workspace.